### PR TITLE
Make it optional to not use \mentor and \promotor.

### DIFF
--- a/uhphysreport.cls
+++ b/uhphysreport.cls
@@ -55,8 +55,15 @@
 \newcommand*{\course}[1]{\gdef\thecourse{#1}}
 \newcommand*{\major}[1]{\gdef\themajor{#1}}
 \newcommand*{\acyear}[1]{\gdef\theacyear{#1}}
-\newcommand*{\mentor}[1]{\gdef\thementor{#1}}
-\newcommand*{\promotor}[1]{\gdef\thepromotor{#1}}
+
+\newcommand*{\thementor}{}
+\newcommand*{\mentor}[1]{\ifx\empty#1\empty  \else \gdef\thementor{\textbf{Begeleider(s):} \\ #1} \fi
+}
+
+\newcommand*{\thepromotor}{}
+\newcommand*{\promotor}[1]{\ifx\empty#1\empty  \else \gdef\thepromotor{\textbf{Promotor(s):} \\ #1} \fi
+}
+
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Definition of the header %
@@ -114,9 +121,9 @@
                 \large 
                 \textbf{Auteur(s):} \\ \@author 
                 \npar
-                \textbf{Begeleider(s):} \\ \thementor 
+                \thementor 
                 \npar
-                \textbf{Promotor(s):} \\ \thepromotor
+                \thepromotor 
         \end{minipage}
     \end{titlepage}
     \cleardoublepage


### PR DESCRIPTION
Make the \mentor and \promotor commands optional.